### PR TITLE
Adding a new database - gun

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Repository for the #1 NoSQL rated list http://nosql-database.org which includes:
 * A blog
 * Great NoSQL Events
 
-We do acceppt pull requests. However there are strict rules.
+We do accept pull requests. However there are strict rules.
 Please have a look at the bottom page -> contact and feedback!
 
 This site is additionally totally independent and has no financial interests.

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ Apache Kudu (incubating) completes Hadoop's storage layer to enable fast analyti
 </article>
 
 <article>
-		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gunDB.io">gun</a></h3>
+		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gunDB.io">GUN</a></h3>
 		(<strong>Doc Store</strong> & GraphDB & Key-Value. More details in Category <a href="#multimodel">Multimodel Databases</a>)
 </article>
 
@@ -823,7 +823,7 @@ Embedded solution.
 	</article>
 
 	<article>
-		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gunDB.io">gun</a></h3>
+		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gunDB.io">GUN</a></h3>
 		(Doc Store & <strong>GraphDB</strong> & Key-Value. More details in Category <a href="#multimodel">Multimodel Databases</a>)
 </article>
 
@@ -998,7 +998,7 @@ Supports multiple graph models. Written in Java
 </article>
 
 <article>
-		<h3><a href="http://gunDB.io">gun</a></h3>
+		<h3><a href="http://gunDB.io">GUN</a></h3>
 		API: <strong>JavaScript</strong>,
 		Schema: <strong>Has features of an Object-Database, DocumentDB, GraphDB and Key-Value DB</strong>,
 		Written in: <strong>JavaScript</strong>,

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ Apache Kudu (incubating) completes Hadoop's storage layer to enable fast analyti
 </article>
 
 <article>
-		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a></h3>
+		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gun.js.org/enterprise/">gun</a></h3>
 		(<strong>Doc Store</strong> & GraphDB & Key-Value. More details in Category <a href="#multimodel">Multimodel Databases</a>)
 </article>
 
@@ -823,7 +823,7 @@ Embedded solution.
 	</article>
 
 	<article>
-		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a></h3>
+		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gun.js.org/enterprise/">gun</a></h3>
 		(Doc Store & <strong>GraphDB</strong> & Key-Value. More details in Category <a href="#multimodel">Multimodel Databases</a>)
 </article>
 
@@ -995,6 +995,18 @@ Supports multiple graph models. Written in Java
 		Indexing: <strong>Primary, Secondary, Composite indexes with support for Full-Text and Spatial</strong>,
 		Replication: <strong>Master-Master + sharding</strong>,
 		Misc: <strong>Really fast, Lightweight, ACID with recovery</strong>.
+</article>
+
+<article>
+		<h3><a href="http://gun.js.org/enterprise/">gun</a></h3>
+		API: <strong>JavaScript</strong>,
+		Schema: <strong>Has features of an Object-Database, DocumentDB, GraphDB and Key-Value DB</strong>,
+		Written in: <strong>JavaScript</strong>,
+		Query Method: <strong>JavaScript</strong>,
+		Concurrency: <strong>   ???   ???   ???   </strong>,
+		Indexing: <strong>   ???   ???   ???   </strong>,
+		Replication: <strong>Peer-to-peer; peers can be clients or servers</strong>,
+		Misc: <strong>Open source, offline first, fully distributed, graph-oriented, and fault-tolerant database</strong>.
 </article>
 
 	<article>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ Apache Kudu (incubating) completes Hadoop's storage layer to enable fast analyti
 </article>
 
 <article>
-		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gun.js.org/enterprise/">gun</a></h3>
+		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gunDB.io">gun</a></h3>
 		(<strong>Doc Store</strong> & GraphDB & Key-Value. More details in Category <a href="#multimodel">Multimodel Databases</a>)
 </article>
 
@@ -823,7 +823,7 @@ Embedded solution.
 	</article>
 
 	<article>
-		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gun.js.org/enterprise/">gun</a></h3>
+		<h3><a href="http://www.arangoDB.com/">ArangoDB</a>, <a href="http://orientdb.com">OrientDB</a>, and <a href="http://gunDB.io">gun</a></h3>
 		(Doc Store & <strong>GraphDB</strong> & Key-Value. More details in Category <a href="#multimodel">Multimodel Databases</a>)
 </article>
 
@@ -998,15 +998,15 @@ Supports multiple graph models. Written in Java
 </article>
 
 <article>
-		<h3><a href="http://gun.js.org/enterprise/">gun</a></h3>
+		<h3><a href="http://gunDB.io">gun</a></h3>
 		API: <strong>JavaScript</strong>,
 		Schema: <strong>Has features of an Object-Database, DocumentDB, GraphDB and Key-Value DB</strong>,
 		Written in: <strong>JavaScript</strong>,
 		Query Method: <strong>JavaScript</strong>,
-		Concurrency: <strong>   ???   ???   ???   </strong>,
-		Indexing: <strong>   ???   ???   ???   </strong>,
-		Replication: <strong>Peer-to-peer; peers can be clients or servers</strong>,
-		Misc: <strong>Open source, offline first, fully distributed, graph-oriented, and fault-tolerant database</strong>.
+		Concurrency: <strong>Eventual consistency with hybrid vector/timestamp/lexical conflict resolution</strong>,
+		Indexing: <strong>O(1) key/value, supports multiple indices per record</strong>,
+		Replication: <strong>Multi-Master/Master; browser peer-to-peer (P2P) enabled</strong>,
+		Misc: <strong>Open source, realtime sync, offline-first, distributed/decentralized, graph-oriented, and fault-tolerant</strong>.
 </article>
 
 	<article>


### PR DESCRIPTION
Hey Dr. Edlich,

We'd love to see our open source, offline first, fully distributed, graph-oriented (technically we're a key-value synch engine), and fault-tolerant database –gun– listed on nosql-database.org.  In the pull request we've added brief entries to the Document Store and Graph Database sub-lists, and a full description to the Multimodal sub-list.

I'm also kind of curious why ArangoDB and OrientDB are not also listed under "Key Value/Tuple Store", as I think all three of us fall under that category.  Since they weren't there, I wanted to make sure I understood why before adding gun there.

Thank you!

~sean
