### PR TITLE
Adding LevelDBWinRT to LevelDB

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@ Secondary & composite indexes. Transparently serializes Java/.NET objects.
 		href="http://google-opensource.blogspot.com/2011/07/leveldb-fast-persistent-key-value-store.html">&raquo;</a>,
 	hot Benchmark <a href="http://leveldb.googlecode.com/svn/trunk/doc/benchmark.html">&raquo;</a>, Article <a
 		href="http://www.golem.de/1107/85298.html">&raquo;</a>
-	(in German). Java <a href="https://github.com/fusesource/leveldbjni">access</a>.
+	(in German). Java <a href="https://github.com/fusesource/leveldbjni">access</a>. C# (for Universal Windows Platform) <a href="https://github.com/maxpert/LevelDBWinRT">access</a>.
 </article>
 
 <article>


### PR DESCRIPTION
Hey Elidch,

I recently ported LevelDB to work with Universal Platform. Library also exposes proper interface to LevelDB via Runtime component. This allows people to use LevelDB on Universal apps (all the way from mobile to Xbox and desktop or WinJS apps). This Change set adds link to LevelDBWinRT a Universal Windows Platform port for LevelDB. 


Thanks,
Zohaib