### PR TITLE
Eventchain was renamed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1597,7 +1597,7 @@ Hybrid database / search engine system with characteristics of multi-value, docu
 <section>
 		<h2>Event Sourcing</h2>
 <article><h3><a href="http://geteventstore.com/">Event Store</a></h3></article>
-<article><h3><a href="http://eventchain.org/">Eventchain</a></h3>
+<article><h3><a href="http://eventsourcing.com/">Eventsourcing for Java (es4j)</a></h3>
 Key features: Clean, succinct Command/Event model, Compact data storage layout, Disruptor for fast message processing, CQengine for fast indexing and querying,
 In-memory and on-disk storage, Causality-preserving Hybrid Logical Clocks, Locking synchronization primitive, OSGi support
 </article>


### PR DESCRIPTION
Eventchain was renamed to Eventsourcing for Java (es4j)