### PR TITLE
Minor edits to Scylla entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,9 +90,10 @@
 	</article>
 
   <article>
-		<h3><a href="http://www.scylladb.com/">ScyllaDB</a></h3>
-  Cassandra compatible rcolumn store with low latency and faster transactions per seconds.
-  Predictable scaling. No pauses under compaction or garbage collection.	
+		<h3><a href="http://www.scylladb.com/">Scylla</a></h3>
+  Cassandra-compatible column store, with consistent low latency and more transactions per second.
+  Designed with a thread-per-core model to maximize performance on modern multicore hardware.
+  Predictable scaling. No garbage collection pauses, and faster compaction.	
   </article>
       
 	<article>


### PR DESCRIPTION
Minor edit for consistency (Scylla is the software, ScyllaDB is the company), and added mention of thread-per-core design.