### PR TITLE
Moved BBoxDB into the 'Key Value / Tuple Store' category

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,6 +879,17 @@ Embedded solution.
    Concurrency: <strong>RW locking</strong>.
    License: <strong>MIT</strong>
 </article>
+	
+	<article>
+		<h3><a href="https://github.com/jnidzwetzki/bboxdb/" target="_blank">BBoxDB</a></h3>
+		A distributed data store for multi-dimensional data. BBoxDB enhances the key-value data model by a bounding box, which describes the location of a value in an n-dimensional space. Data can be efficiently retrieved using hyperrectangle queries. Spatial joins and dynamic data redistribution are also supported.
+		API: <strong>Java</strong>,
+		Protocol: <strong>asynchronous binary</strong>,
+		Data model: <strong>Key-bounding-box-value</strong>,
+		Scaling: <strong>Auto-Sharding, Replication</strong>,
+		Written in: <strong>Java</strong>,
+		Concurrency: <strong>eventually consistent / RW locking</strong>
+	</article>
 
 <article class="grey">
 	<p>
@@ -1036,17 +1047,6 @@ Supports multiple graph models. Written in Java
 
 	<article><h3><a href="http://www.openlinksw.com/">OpenLink Virtuoso</a></h3>
 		<strong>Hybrid</strong> DBMS covering the following models: <strong>Relational, Document, Graph</strong>
-	</article>
-	
-	<article>
-		<h3><a href="https://github.com/jnidzwetzki/bboxdb/" target="_blank">BBoxDB</a></h3>
-		A distributed data store for multi-dimensional data. BBoxDB enhances the key-value data model by a bounding box, which describes the location of a value in an n-dimensional space. Data can be efficiently retrieved using hyperrectangle queries. Spatial joins and dynamic data redistribution are also supported.
-		API: <strong>Java</strong>,
-		Protocol: <strong>asynchronous binary</strong>,
-		Data model: <strong>Key-bounding-box-value</strong>,
-		Scaling: <strong>Auto-Sharding, Replication</strong>,
-		Written in: <strong>Java</strong>,
-		Concurrency: <strong>eventually consistent / RW locking</strong>
 	</article>
 
 	<article><h3><a href="http://www.dekorte.com/projects/opensource/vertexdb/">VertexDB</a></h3></article>


### PR DESCRIPTION
BBoxDB was was accidentally placed in the 'Graph Databases' category. This PR moves BBoxDB into the 'Key Value / Tuple Store' category