### PR TITLE
JDX: in-memory document database

### DIFF
--- a/index.html
+++ b/index.html
@@ -898,6 +898,14 @@ Embedded solution.
    Protocol: <strong>HTTP</strong>.
    Writen in: <strong>C</strong>.
 </article>
+
+<article>
+   <h3><a href="http://js2dx.com">JDX</a></h3>
+   A lightweight in-memory document-oriented database written with JavaScript.
+   Includes Single Page Application API, node serialization, tree browsing and CRUD operations on document tuples through web GUI.
+   Integrate with server-side noSQL database instance into a transaction-synchronous cluster, create SPA content
+   or browse and serialize document tuples with HTML interface.
+</article>
 	
 <article class="grey">
 	<p>
@@ -1566,7 +1574,6 @@ Oracle Coherence offers distributed, replicated, multi-datacenter, tiered (off-h
 	[
 	<a href="http://xml.apache.org/xindice/">Xindice</a>, 
 	<a href="http://www.softwareag.com/de/products/wm/tamino/">Tamino</a>, 
-	<a href="http://js2dx.com/">2DX</a>
 	]
 </article>
 


### PR DESCRIPTION
Added entry for **JDX** - an in-memory document database written with JavaScript with Single Page Application API. Formerly 2DX, which was removed from listing.