### PR TITLE
Update RavenDB link and description

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,11 +323,8 @@ at &lt;15ms. Scale to handle 10s-100s of millions of requests/sec and replicate 
 	</article>
 
 	<article>
-		<h3><a href="http://github.com/ravendb/ravendb">RavenDB</a></h3>
-		.Net solution. Provides <strong>HTTP/JSON</strong>
-		access. <strong>LINQ</strong>
-		queries &amp; <strong>Sharding</strong>
-		supported. <a href="http://www.codeproject.com/KB/cs/RavenDBIntro.aspx">&raquo; Misc</a>
+		<h3><a href="https://www.ravendb.net">RavenDB</a></h3>
+		RavenDB is an Open Source NoSQL Database. <strong>Multi-Model:</strong> Document, Key-Value, Graph, Distributed Counters, Attachments. Fully Transactional (ACID) across database and throughout the cluster. <strong>Multiplatform:</strong> C#, Node.js, Java, Python, Ruby, Go. <strong>Multisystem:</strong> Windows, Linux, Mac OS, Docker, Raspberry Pi. Native GUI, MapReduce, full text search, memory management.
 	</article>
 
 <article>


### PR DESCRIPTION
fixed the link and provided a deeper description -- facts, not promotion and less than 400 characters.