### PR TITLE
Add the UnQlite NoSQL DB

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,6 +327,14 @@ at &lt;15ms. Scale to handle 10s-100s of millions of requests/sec and replicate 
 		RavenDB is an Open Source NoSQL Database. <strong>Multi-Model:</strong> Document, Key-Value, Graph, Distributed Counters, Attachments. Fully Transactional (ACID) across database and throughout the cluster. <strong>Multiplatform:</strong> C#, Node.js, Java, Python, Ruby, Go. <strong>Multisystem:</strong> Windows, Linux, Mac OS, Docker, Raspberry Pi. Native GUI, MapReduce, full text search, memory management.
 	</article>
 
+	<article>
+		<h3><a href="https://unqlite.org/">UnQlite</a></h3>
+		UnQLite is an embedded NoSQL (<strong>Key/Value</strong> store and <strong>Document-store</strong>) database engine.
+		Similar to MongoDB, Redis, CouchDB etc. as well a standard Key/Value store similar to BerkeleyDB, LevelDB, etc.
+		It's a in-process software library which implements a self-contained, serverless, zero-configuration, transactional NoSQL database engine.
+		Open source, distribuited under the <strong>2-Clause BSD license</strong>.
+	</article>
+
 <article>
 	<h3><a href="http://www.marklogic.com/">MarkLogic Server</a></h3>
 	(developer+commercial) 


### PR DESCRIPTION
Hi,

This commit add the UnQlite NoSQL DB to the list of DBs. It's released under the 2-Clause BSD license. For more info, please, refer to: https://unqlite.org/ for more infos.

Thanks,
Luca