### PR TITLE
Entry for Levyx's Helium KV

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,6 +570,16 @@ Secondary & composite indexes. Transparently serializes Java/.NET objects.
 </article>
 
 <article>
+	<h3><a href="https://www.levyx.com/helium" target="_blank">Helium</a></h3>
+	API: <strong>C, C++, Java, Python, NodeJS</strong>. Written in C.
+        Key-value store aimed at high throughput and low latency (usecs) applications.
+        Designed to run on many-core systems with fast storage such as SSDs and NVMs. Low and predictable memory footprint, low write amplification.
+	License: <strong>proprietary</strong> Mode: <strong>embedded, single server</strong><strong>Links</strong>
+	<a href="https://cloudplatform.googleblog.com/2015/07/Multi-million-operations-per-second-on-a-single-Google-Cloud-Platform-instance.html" target="_blank">Multi million ops/sec on GCP</a>,
+	<a href="https://www.samsung.com/semiconductor/global.semi.static/Whitepaper_Samsung_Low_Latency_Z-SSD_Levyx_Helium_Data_Store_Jan2018.pdf" target="_blank">Real-time low latency KV with Helium and Samsung Z-SSD</a>
+</article>
+
+<article>
 	<h3><a href="https://github.com/JohnSully/KeyDB" target="_blank">KeyDB</a></h3>
 	API:
 	<strong>Multiple languages (Redis Compatible)</strong>


### PR DESCRIPTION
This is an entry for Levyx Inc., Helium key-value store. It is in the same class as BerkeleyDB, RocksDB, LevelDB.
